### PR TITLE
PHP5.4 - OAuthFetcher - Even if the data array is not empty, it will still return true for the empty function

### DIFF
--- a/Twitter/LastTweetsFetcher/OAuthFetcher.php
+++ b/Twitter/LastTweetsFetcher/OAuthFetcher.php
@@ -25,7 +25,7 @@ class OAuthFetcher extends ApiFetcher
         if (null === $data) {
             throw new TwitterException('Unable to decode data: ' . json_last_error());
         }
-        if (empty($data)) {
+        if ($data === false) {
             throw new TwitterException('Received empty data from api.twitter.com');
         }
         if (isset($data['error'])) {


### PR DESCRIPTION
We have a valid response from the server and I checked that the array was not empty, however, when applying the function empty on the array, it always returns true.

```
       if (empty($data)) {
            throw new TwitterException('Received empty data from api.twitter.com');
        }

```

I've added:

```
        if ($data === false) {
            throw new TwitterException('Received empty data from api.twitter.com');
        }
```

By default, if an array is empty, it'll return false.

In the php documentation (http://fr2.php.net/empty)

It states:

5.4.0     Checking non-numeric offsets of strings returns TRUE.

5.0.0    Objects with no properties are no longer considered empty. 

Perhaps this is the problem or it's a bug in php?

Let me know your thoughts.
