### PR TITLE
Add target attribute to urlized links

### DIFF
--- a/Tests/Twig/Extension/TweetUrlizeTwigExtensionTest.php
+++ b/Tests/Twig/Extension/TweetUrlizeTwigExtensionTest.php
@@ -43,4 +43,48 @@ class TweetUrlizeTwigExtensionTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
+
+    /**
+     * @dataProvider getUrlizedTargetData
+     */
+    public function testUrlizeTarget($expected, $text, $target)
+    {
+        $this->assertEquals($expected, TweetUrlizeTwigExtension::urlize($text, $target));
+    }
+
+    public function getUrlizedTargetData()
+    {
+        return array(
+            array(
+                'I am <a href="http://twitter.com/mbontemps" target="_blank">@mbontemps</a>. What about you?',
+                'I am @mbontemps. What about you?',
+                '_blank'
+            ),
+            array(
+                'I am <a href="http://twitter.com/search/symfony" target="_self">#symfony</a>. What about you?',
+                'I am #symfony. What about you?',
+                '_self'
+            ),
+            array(
+                'I am <a href="http://www.knplabs.com/en" target="_parent">http://www.knplabs.com/en</a> - What about you?',
+                'I am http://www.knplabs.com/en - What about you?',
+                '_parent'
+            ),
+            array(
+                'I am <a href="http://www.knplabs.com/en" target="_top">www.knplabs.com/en</a> - What about you?',
+                'I am www.knplabs.com/en - What about you?',
+                '_top'
+            ),
+            array(
+                "I&#039;m here",
+                "I&#039;m here",
+                'frame-name'
+            ),
+            array(
+                '<a href="http://twitter.com/search/hashMe">#hashMe</a> atTheBeginning',
+                "#hashMe atTheBeginning",
+                null
+            ),
+        );
+    }
 }

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -2,10 +2,10 @@
 
 $vendorDir = __DIR__ . '/../vendor';
  
-if (!@include($vendorDir . '/.composer/autoload.php')) {
+if (!@include($vendorDir . '/autoload.php')) {
     die("You must set up the project dependencies, run the following commands:
 wget http://getcomposer.org/composer.phar
-php composer.phar install
+php composer.phar install --dev
 ");
 }
  

--- a/Twig/Extension/TweetUrlizeTwigExtension.php
+++ b/Twig/Extension/TweetUrlizeTwigExtension.php
@@ -11,9 +11,9 @@ class TweetUrlizeTwigExtension extends \Twig_Extension
         );
     }
 
-    public function filterTweet($text)
+    public function filterTweet($text, $target = null)
     {
-        return self::urlize($text);
+        return self::urlize($text, $target);
     }
 
     /**
@@ -21,19 +21,20 @@ class TweetUrlizeTwigExtension extends \Twig_Extension
      * Should be moved to a Renderer class in order for it to be used by 
      * something else than twig
      * 
-     * @param string A tweet
-     * @return the urlized tweed
+     * @param string $text A tweet
+     * @param string $target Link target attribute
+     * @return string the urlized tweed
      */
-    static public function urlize($text)
+    static public function urlize($text, $target = null)
     {
-        $text = preg_replace("#(^|[\n ])([\w]+?://[\w]+[^ \"\n\r\t< ]*)#", "\\1<a href=\"\\2\">\\2</a>", $text);
-        $text = preg_replace("#(^|[\n ])((www|ftp)\.[^ \"\t\n\r< ]*)#", "\\1<a href=\"http://\\2\">\\2</a>", $text);
-        $text = preg_replace("/@(\w+)/", "<a href=\"http://twitter.com/\\1\">@\\1</a>", $text);
-        $text = preg_replace("/([^&]|^)#(\w+)/", "\\1<a href=\"http://twitter.com/search/\\2\">#\\2</a>", $text);
+        $target = $target === null ? '' : ' target="' . $target . '"';
+        $text = preg_replace("#(^|[\n ])([\w]+?://[\w]+[^ \"\n\r\t< ]*)#", "\\1<a href=\"\\2\"".$target.">\\2</a>", $text);
+        $text = preg_replace("#(^|[\n ])((www|ftp)\.[^ \"\t\n\r< ]*)#", "\\1<a href=\"http://\\2\"".$target.">\\2</a>", $text);
+        $text = preg_replace("/@(\w+)/", "<a href=\"http://twitter.com/\\1\"".$target.">@\\1</a>", $text);
+        $text = preg_replace("/([^&]|^)#(\w+)/", "\\1<a href=\"http://twitter.com/search/\\2\"".$target.">#\\2</a>", $text);
 
         return $text;
     }
-
 
     public function getName()
     {


### PR DESCRIPTION
I needed the ability to set the target attribute in the `a` tags the `knp_tweet_urlize` filter created. I have added a `$target` parameter so this can be customized. A test has been created for the new functionality. I have also updated `Tests/bootstrap.php` so that it conforms to the current version of composer.
